### PR TITLE
U/alexandrunita/84

### DIFF
--- a/ActionPlans/Start-DecodeSafeLinksURL.ps1
+++ b/ActionPlans/Start-DecodeSafeLinksURL.ps1
@@ -13,7 +13,7 @@ catch
     Write-Log -function "Start-AP_DecodeSafeLinksURL" -step  "Decoding URL" -Description "Couldn't decode and parse URL: $encodedURL"
     Write-Host "Couldn't decode and parse URL: $encodedURL"
     Read-Host "Press any key and then to reload main menu [Enter]"
-    Start-O365Troubleshooters
+    Start-O365TroubleshootersMenu
 }
 
 Write-Host "The decoded URL is:" -ForegroundColor Green

--- a/ActionPlans/Start-DecodeSafeLinksURL.ps1
+++ b/ActionPlans/Start-DecodeSafeLinksURL.ps1
@@ -1,5 +1,6 @@
 Clear-Host
 $encodedURL  = Read-Host("Please provide the ATP SafeLinks URL that you want to decode to original URL")
+Add-Type -AssemblyName System.Web
 
 try
 {

--- a/O365Troubleshooters.psd1
+++ b/O365Troubleshooters.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\O365Troubleshooters.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.0.0.9'
+ModuleVersion = '2.0.0.10'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -124,6 +124,7 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = '
+        2.0.0.10 - Fixed issue with Decode SafeLinks URL
         2.0.0.7 - Added Azure Sign in logs
         2.0.0.6 - Module deployed with main functions and the following action plans: OME, SMTP Relay, EXO Audit, Unified Audit, Find All Users with Specific RBAC, Export all users with RBAC, Export Mailbox Diagnostics logs, Decode ATP SafeLinks, Export Quarantine
         '


### PR DESCRIPTION
When "Decode SafeLinks URL" fails to decode a URL, it will now send the user to Start-O365TroubleshootersMenu, as expected.

Implemented explicit System.Web Assembly load to resolve:
decodedURL = [System.Web.HttpUtility]::UrlDecode($encodedURL)
Unable to find type [System.Web.HttpUtility].