### PR TITLE
Change connections to workloads to use tokens if no MFA

### DIFF
--- a/ActionPlans/Connect-ServicesWithTokens.ps1
+++ b/ActionPlans/Connect-ServicesWithTokens.ps1
@@ -111,7 +111,16 @@ function Get-TokenFromCache
         }
     }
 
+    #returning token from cache
     $cache = [Microsoft.IdentityModel.Clients.ActiveDirectory.TokenCache]::DefaultShared
-    return $Cache.ReadItems() | Where-Object {($_.DisplayableId -eq $global:credentials.userName) -and ($_.Resource -eq $resourceID)}
-   
+    $token = $Cache.ReadItems() | Where-Object {($_.DisplayableId -eq $global:credentials.userName) -and ($_.Resource -eq $resourceID)}
+    # Check if access token lifetime is less than 30 minutes to request a new access token
+    if ($token)
+    {
+        if (($token.ExpiresOn - (get-date)).Totalminutes -lt 30)
+        {
+            return $null
+        }
+    }
+    return $token
 }

--- a/ActionPlans/Connect-ServicesWithTokens.ps1
+++ b/ActionPlans/Connect-ServicesWithTokens.ps1
@@ -48,7 +48,7 @@ function Get-Token {
     while ($authResult.IsCompleted -ne $true) { Start-Sleep -Milliseconds 500}
     if (!($authResult.IsFaulted -eq $false)) 
     {
-        switch ($Result.Exception.InnerException.ErrorCode) 
+        switch ($authResult.Exception.InnerException.ErrorCode) 
         {
             failed_to_acquire_token_silently 
             {
@@ -83,8 +83,7 @@ function Get-Token {
     return $authResult.Result
 }
 
-function Get-TokenFromCache
-{
+function Get-TokenFromCache {
     param (
         [Parameter(Mandatory = $true)]
         [ValidateSet("EXO","AzureGraph","AIPService")]

--- a/ActionPlans/Start-CompromisedInvestigation.ps1
+++ b/ActionPlans/Start-CompromisedInvestigation.ps1
@@ -373,7 +373,7 @@ Function Start-CompromisedMain
     Clear-Host
 
     #Connect to O365 Workloads
-    $Workloads = "Exo2", "MSOL", "AzureADPreview"#, "AAD", "SCC"
+    $Workloads = "Exo", "MSOL", "AzureADPreview"#, "AAD", "SCC"
     
     Connect-O365PS $Workloads
 


### PR DESCRIPTION
Change connections to workloads to use tokens if no MFA
- implemented Get-TokenFromCache
- will provide the token from cache if all conditions are met:
       - exists for an user 
       - is issued for the required service
       - will expire in more than 30 minutes