### PR TITLE
use only default modern authentication window

### DIFF
--- a/O365Troubleshooters.psm1
+++ b/O365Troubleshooters.psm1
@@ -289,9 +289,10 @@ Function Connect-O365PS {
 
         if ($global:MfaOption -eq 0) {
             do {
-
-                Write-Host "Do your account require MFA to authenticate? (y/n): " -ForegroundColor Cyan -NoNewline
-                $mfa = Read-Host 
+                # use only default modern authentication window (temporary disable manual managed tokens)
+                #Write-Host "Do your account require MFA to authenticate? (y/n): " -ForegroundColor Cyan -NoNewline
+                #$mfa = Read-Host 
+                $mha = "y"
                 $mfa = $mfa.ToLower()
                 if ($mfa -eq "y") {
                     $global:MfaOption = 1


### PR DESCRIPTION
disable temporary manual token manipulation to avoid multiple prompts